### PR TITLE
Do not fail hash validation

### DIFF
--- a/native_client_sdk/src/build_tools/sdk_tools/command/update.py
+++ b/native_client_sdk/src/build_tools/sdk_tools/command/update.py
@@ -74,7 +74,7 @@ class RealUpdateDelegate(UpdateDelegate):
           archive.size, filename))
       return False
     sha1_hash = hashlib.sha1()
-    with open(filename) as f:
+    with open(filename, 'rb') as f:
       sha1_hash.update(f.read())
     if sha1_hash.hexdigest() != archive.GetChecksum():
       logging.info('File hash does not match: %s.' % filename)


### PR DESCRIPTION
At least on Windows hash validation for downloaded files
always fails, because files are opened in text mode